### PR TITLE
added go back button for all games pages

### DIFF
--- a/games/hangman.html
+++ b/games/hangman.html
@@ -237,6 +237,8 @@ section{
     #newGameButton:hover {
       background-color: #019875;
     }
+    
+    
   </style>
 </head>
 <body>
@@ -263,7 +265,11 @@ section{
 
   <!-- ADD SPACING AFTER NAVBAR -->
   <div style="height: 100px;"></div>
-
+  <!--Add Go Back Navigation Button-->
+ <a href="../games/gamess.html"  
+  style="text-decoration: none; color:rgb(87, 4, 4); font-weight: 600;  position: absolute; top:85px; left:20px;"
+   onmouseover="this.style.textDecoration='underline'"
+   onmouseout="this.style.textDecoration='none'">&larr; Go Back</a>
   <!-- PAGE TITLE OUTSIDE THE CARD -->
   <h1 style="text-align: center; color: #555172; margin-bottom: 20px;">Hangman - CS Terms</h1>
 

--- a/games/memory.html
+++ b/games/memory.html
@@ -104,7 +104,14 @@ body {font-family: 'IBM Plex Sans', sans-serif; text-align: center; padding: 60p
     </ul>
     <img src="../images/moon.png" id="mode" alt="Change mode" title="change mode">
   </nav> 
-
+<!-- ADD SPACING AFTER NAVBAR -->
+  <div style="height: 70px;"></div>
+  <!--Add Go Back Navigation Button-->
+    <a href="../games/gamess.html"  
+  style="text-decoration: none; color:rgb(87, 4, 4); font-weight: 600;  position: absolute; top:85px; left:20px;"
+   onmouseover="this.style.textDecoration='underline'"
+   onmouseout="this.style.textDecoration='none'">&larr; Go Back</a>
+  
   <h1>🌈 Colorful Memory Match</h1>
 
   <div class="game-info">

--- a/games/quiz.html
+++ b/games/quiz.html
@@ -136,7 +136,13 @@
     </ul>
     <img src="../images/moon.png" id="mode" alt="Change mode" title="change mode">
   </nav> 
-
+  <!-- ADD SPACING AFTER NAVBAR -->
+  <div style="height: 70px;"></div>
+  <!--Add Go Back Navigation Button-->
+  <a href="../games/gamess.html"  
+  style="text-decoration: none; color:rgb(87, 4, 4); font-weight: 600;  position: absolute; top:85px; left:20px;"
+   onmouseover="this.style.textDecoration='underline'"
+   onmouseout="this.style.textDecoration='none'">&larr; Go Back</a>
   <h2>🧪 Basic Coding Quiz</h2>
   <div class="quiz-box">
     <div class="progress"><div class="progress-bar" id="bar"></div></div>

--- a/games/typing.html
+++ b/games/typing.html
@@ -119,6 +119,13 @@
     </ul>
     <img src="../images/moon.png" id="mode" alt="Change mode" title="change mode">
   </nav>  
+  <!-- ADD SPACING AFTER NAVBAR -->
+  <div style="height: 70px;"></div>
+  <!--Add Go Back Navigation Button-->
+  <a href="../games/gamess.html"  
+  style="text-decoration: none; color:rgb(87, 4, 4); font-weight: 600;  position: absolute; top:85px; left:20px;"
+   onmouseover="this.style.textDecoration='underline'"
+   onmouseout="this.style.textDecoration='none'">&larr; Go Back</a>
 
     <h1 >💻 Typing Speed Challenge</h1>
     <div id="sentenceDisplay" class="sentence"></div>


### PR DESCRIPTION
## Summary
Added a "Go Back" link with a left arrow icon (&larr;) to the main games page.
Link has hover underline effect and is positioned at the top-left.

## Changes Made
- Added HTML link to ../games/gamess.html
- Applied inline CSS for color, font-weight, and hover underline
- Positioned link using absolute positioning

## Screenshots
**Before:**
<img width="1440" height="864" alt="Screenshot (480)" src="https://github.com/user-attachments/assets/76a9cd45-51f6-4975-a57e-ea983cff65c9" />
<img width="1440" height="864" alt="Screenshot (481)" src="https://github.com/user-attachments/assets/9163dd91-6b26-4a04-ab37-dc08628b9068" />
<img width="1440" height="864" alt="Screenshot (483)" src="https://github.com/user-attachments/assets/b49f24d4-da27-4a8d-946f-1eee6dd6f14b" />
<img width="1440" height="864" alt="Screenshot (484)" src="https://github.com/user-attachments/assets/0907565d-879c-4b91-9d81-7294bee0d253" />


**After:**
<img width="2880" height="1734" alt="Screenshot (486)" src="https://github.com/user-attachments/assets/7fe3a70b-e28e-48f2-9de5-2d3f389b8024" />
<img width="2880" height="1740" alt="Screenshot (487)" src="https://github.com/user-attachments/assets/c01c6f2e-fb1e-40a3-a1fe-a7b9e98493b1" />
<img width="2880" height="1740" alt="Screenshot (488)" src="https://github.com/user-attachments/assets/4ff6eed6-8082-44a8-9bb5-d68ddba441de" />
<img width="2880" height="1740" alt="Screenshot (489)" src="https://github.com/user-attachments/assets/dba9bf59-2502-4b99-9ffd-2f443724af52" />


