### PR TITLE
Fix: Removed Google Translate popup issue on Contact Us page (#280)

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -615,11 +615,7 @@
             }, 2000);
         });
     </script>
-    <script src="../index.js"></script>
-    <!-- Google Translate -->
-<div id="google_translate_element" style="display:none;"></div>
-
-<script src="../language.js"></script>
+    
 </body>
 
 </html>


### PR DESCRIPTION
## 🔖 PR Title:
Fix: Removed Google Translate popup issue on Contact Us page (#280)

---

## 📄 Description:
This PR fixes the issue where clicking the "Contact Us" link opened an unintended Google Translate popup.


- [ ] Bug Fix ✅
- [ ] New Feature ✨
- [ ] Enhancement 🔧
- [ ] Documentation 📝
- [ ] UI/UX Update 🎨

---

## 🧑‍💻 What changes were made?

- Removed <div id="google_translate_element" style="display:none;"></div> from pages/contact.html.
- Removed <script src="../language.js"></script> from pages/contact.html
- Verified that the Contact Us link now works without triggering Google Translate.

---

## 📚 Documentation Updated?
- [ ] Yes, I have updated the relevant section in `README.md` or related files.

---

## 🖼️ Screenshot or Screen Recording (max 15 seconds)
**Before:**
<img width="1909" height="936" alt="Screenshot 2025-08-21 180232" src="https://github.com/user-attachments/assets/350e4845-7b3f-4414-b8e1-4fac1fc69989" />

**After:**
<img width="1910" height="950" alt="Screenshot 2025-08-24 143914" src="https://github.com/user-attachments/assets/486ff41f-db79-4db5-b364-83c76c45c078" />



---

## 💡 Tech Stack Used:
HTML / CSS / JavaScript

---

## List of File Changed :
pages/contact.html
# no. of file changed :1



## 🔗 Issue Reference:
Closes #280


---

## 🧩 Contribution Type:
- Bug Fix 🐛


---
