### PR TITLE
[Fix]: Prevent language reset when toggling between English and Hindi

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+
 // ===== Navbar & Scroll Handling =====
 const element = document.getElementById('scroll-hide');
 const mode = document.getElementById("mode");

--- a/index.js
+++ b/index.js
@@ -107,36 +107,37 @@ if (!document.querySelector('script[src*="translate.google.com"]')) {
     document.body.appendChild(translateScript);
 }
 
-function waitForTranslate(callback) {
-    const interval = setInterval(() => {
-        const select = document.querySelector(".goog-te-combo");
-        if (select) {
-            clearInterval(interval);
-            callback(select);
-        }
-    }, 500);
-}
-
 function initLanguageToggle() {
-    const langToggle = document.getElementById("lang-toggle");
-    if (!langToggle) return;
+  const langToggle = document.getElementById("lang-toggle");
+  if (!langToggle) return;
 
-    waitForTranslate((select) => {
-        // Apply saved language immediately
-        const savedLang = localStorage.getItem("lang") || "en";
-        select.value = savedLang;
+  waitForTranslate((select) => {
+    // Helper to apply a language and keep the button text in sync
+    const applyLang = (lang) => {
+      if (select.value !== lang) {
+        select.value = lang;
         select.dispatchEvent(new Event("change"));
-        langToggle.innerText = savedLang === "en" ? "हिंदी" : "English";
+      } else {
+        // Re-fire change in case GT reset internally
+        select.dispatchEvent(new Event("change"));
+      }
+      langToggle.innerText = lang === "en" ? "हिंदी" : "English";
+    };
 
-        // Toggle click
-        langToggle.addEventListener("click", function () {
-            const newLang = select.value === "en" ? "hi" : "en";
-            select.value = newLang;
-            select.dispatchEvent(new Event("change"));
-            langToggle.innerText = newLang === "en" ? "हिंदी" : "English";
-            localStorage.setItem("lang", newLang);
-        });
-    });
+    // Restore saved language after a short delay so GT finishes initializing
+    const savedLang = localStorage.getItem("lang") || "en";
+    setTimeout(() => applyLang(savedLang), 500);
+
+    // Guard to avoid attaching the click handler multiple times
+    if (!langToggle.dataset.bound) {
+      langToggle.addEventListener("click", () => {
+        const newLang = select.value === "en" ? "hi" : "en";
+        localStorage.setItem("lang", newLang);
+        applyLang(newLang);
+      });
+      langToggle.dataset.bound = "true";
+    }
+  });
 }
 
 // Run on every page load


### PR DESCRIPTION
## 🔖 PR Title:
Fix: Prevent language reset when toggling between English and Hindi

---

## 📄 Description:
This PR fixes the bug where the site reverts to Hindi after changing to English.
The fix ensures that the saved language preference is applied consistently using localStorage and delayed initialization.

- [x] Bug Fix ✅

<img width="1841" height="835" alt="image" src="https://github.com/user-attachments/assets/4db57bca-0b2a-489f-8a37-90fdc4868be4" />


