### PR TITLE
fix: correct path for pr-contributors.html in index.html (fixes #389)

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,7 +612,7 @@
                             A growing community of student developers working together to improve the platform.
                         </p>
                         <div class="social-links">
-                            <a href="pr-contributors.html">
+                            <a href="/pages/pr-contribution/pr-contributors.html">
                                 <i class="fas fa-users"></i>
                             </a>
                         </div>


### PR DESCRIPTION
### Fixes #389

#### Summary
Corrected the wrong file path for **pr-contributors.html** in `index.html`.

#### Changes Made
- Updated the link in `index.html` to point to the correct path for `pr-contributors.html`.

#### Checklist
- [x] Bug fix
- [x] Verified the link now works correctly
