### PR TITLE
Redesigned the papers page to match the notes page

### DIFF
--- a/pages/paper.css
+++ b/pages/paper.css
@@ -1300,3 +1300,42 @@ body.dark .topic[data-match="true"] summary {
   background: #3a3f57;
   color: #fff;
 }
+
+.papers-flex{
+  display: grid;
+    row-gap: 30px;
+    column-gap: 50px;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 0fr);
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-top:100px;
+}
+.pdf-modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background: rgba(0,0,0,0.7);
+}
+.pdf-modal-content {
+  background: #fff;
+  margin: 5% auto;
+  padding: 10px;
+  border-radius: 10px;
+  width: 80%;
+  max-width: 900px;
+  position: relative;
+}
+.pdf-modal-close {
+  position: absolute;
+  top: 8px;
+  right: 15px;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;}

--- a/pages/paper.css
+++ b/pages/paper.css
@@ -1301,7 +1301,7 @@ body.dark .topic[data-match="true"] summary {
   color: #fff;
 }
 
-.papers-flex{
+/* .papers-flex{
   display: grid;
     row-gap: 30px;
     column-gap: 50px;
@@ -1311,7 +1311,23 @@ body.dark .topic[data-match="true"] summary {
     align-items: center;
     width: 100%;
     margin-top:100px;
+} */
+ .papers-flex {
+  display: grid;
+  gap: 30px 50px; 
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-auto-rows: auto;
+  justify-content: center;
+  align-items: stretch;
+  width: 100%;
+  margin-top: 70px;
 }
+
+.papers-flex .category-card {
+  height: 100%;
+  box-sizing: border-box;
+}
+
 .pdf-modal {
   display: none;
   position: fixed;

--- a/pages/paper.html
+++ b/pages/paper.html
@@ -36,6 +36,7 @@
     <link rel="stylesheet" href="../css/floating-sidebar.css">
 </head>
 
+
 <body id="onload">
   <!-- Scroll Progress Indicator -->
 
@@ -76,240 +77,800 @@
                 and boost your confidence. <span>Nitra Mitra</span> ensures that you have access to the best resources
                 to
                 excel in your academic journey.</p>
-            <h1 class="service-heading" color="black">1st year</h1>
 
-            <div class="about-flex">
-                <div class="About-card">
-                    <!-- <div class="icon">
-                <i class="fa-solid fa-code"></i>
-            </div>
-            <h2 class="name">Electrical</h2>-->
-                    <a href="https://drive.google.com/drive/folders/1vw_A-70PJf-KOoEMsOTaZ7-Gq-fmO9T9"
-                        class="primary-button" id="btn">NTC PYQ</a>
-                </div>
-
-
-                <div class="About-card">
-                    <!-- <div class="icon">
-                <i class="fa-solid fa-code"></i>
-            </div>
-            <h2 class="name">Electrical</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1L9BFpI6LZWKvQINWSX61BD7rYSWUZeY_"
-                        class="primary-button" id="btn">Electrical</a>
-                </div>
-
-                <div class="About-card">
-
-                    <!--<div class="icon">
-            <i class="fa-solid fa-code"></i>
-            </div>
-            <h2 class="name">Chemistry</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1LFkNAm1lkf0xxjivBi4mAc3hmU26U4q7"
-                        class="primary-button" id="btn">
-                        <obj>Physics</obj>
-                    </a>
-
-                </div>
-                <div class="About-card">
-                    <!--<div class="icon">
-                <i class="fa-solid fa-code"></i>
-            </div>
-            <h2 class="name">EVS</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1Pak1zQcim5OvbjZqSzAggZsLTM2E_whU"
-                        class="primary-button" id="btn">Pps</a>
-                </div>
-
-                <div class="About-card">
-                    <!--<div class="icon">
-        <i class="fa-solid fa-code"></i>
-        </div>
-        <h2 class="name">Mathematics</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1LAyqCDR4NmWs28vL54IQWCpiMQ82JQAK"
-                        class="primary-button" id="btn">Environment</a>
-                </div>
-
-                <div class="About-card">
-                    <!--<div class="icon">
-        <i class="fa-solid fa-code"></i>
-        </div>
-        <h2 class="name">Electronics</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1LD7W5HDidZD7tsmABAXLtoGg78Fa-8TP"
-                        class="primary-button" id="btn">Mathematics ii</a>
-                </div>
-
-                <div class="About-card">
-                    <!--<div class="icon">
-    <i class="fa-solid fa-code"></i>
-    </div>
-    <h2 class="name">Physics</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1LB75HlO9lIO4g14MlavxJsz4uaWNDgSw"
-                        class="primary-button" id="btn">Electronics</a>
-                </div>
-
-                <div class="About-card">
-                    <!-- <div class="icon">
-        <i class="fa-solid fa-code"></i>
-        </div>
-        <h2 class="name">Soft Skills</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1LAUR9XSt-qL_87Pi9FofFBGMPdg1eoWl"
-                        class="primary-button" id="btn">Chemistry</a>
-                </div>
-
-
-                <div class="About-card">
-                    <!--<div class="icon">
-            <i class="fa-solid fa-code"></i>
-            </div>
-            <h2 class="name">PPS</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1NtacsaPIeuQM3LDKkQYZcpY0Jt0nfeEh"
-                        class="primary-button" id="btn">Mechanics</a>
-                </div>
-
-
-
-
-                <div class="About-card">
-                    <!--<div class="icon">
-                <i class="fa-solid fa-code"></i>
-                </div>
-                <h2 class="name">Mechanical</h2>-->
-                    <a href="https://drive.google.com/folderview?id=1LIgQOJBZnhUuSK08Wh7M7tGu_00Y2W-i"
-                        class="primary-button" id="btn">Soft Skill</a>
-                </div>
-
-
-            </div>
-            <div class="about " id="about">
-                <h1 class="service-heading" color="black">2nd year</h1>
-
-                <div class="about-flex">
-                    <div class="About-card">
-                        <!-- <div class="icon">
-                <i class="fa-solid fa-code"></i>
-            </div>
-            <h2 class="name">Electrical</h2>-->
-                        <a href="https://drive.google.com/drive/folders/1wfa1pJ0Q5sbOAMfZfNVPrMK5hzZjawoB"
-                            class="primary-button" id="btn">NTC PYQ</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/drive/folders/1Z5M0RilFDjJqvdVId5Xdilla4Ns0DBqS"
-                            class="primary-button" id="btn">COA</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/drive/folders/1tXX24VpGESqJRcYALey6OINK5SVVMEEr"
-                            class="primary-button" id="btn">DSA</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/drive/folders/1gcnSwtJfJoi-MTETw4QfmyxeQ7qFdMUA"
-                            class="primary-button" id="btn">Discrete Math</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/drive/folders/1ha5tl9zvFdXXFEIy0aP0gIlBRCEZTz9I"
-                            class="primary-button" id="btn">Python</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/drive/folders/1TLBdKUdCtn_PfKeFDlt-cRZGezL-d_kQ"
-                            class="primary-button" id="btn">Tech. Comm.</a>
-                    </div>
-
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/folderview?id=1QMYE_HxQWT2hxy1Dn3V0HmWH69_C3R36"
-                            class="primary-button" id="btn">TAFL</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/folderview?id=1Q9jNU4zS3Fs23_lIWzwV7wIU305UQftQ"
-                            class="primary-button" id="btn">Operating Sys.</a>
-                    </div>
-
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/folderview?id=1Q9YhYUjfcCd7VEKtmNuw3YAfaN4dq_9_"
-                            class="primary-button" id="btn">JAVA</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/folderview?id=1Q6GdX3BuVJY5U6PxNyhxCJm3fFzHvSje"
-                            class="primary-button" id="btn">Material</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/folderview?id=1Q8wviF2RkbPZ0SptOi7H8ukEYLAlWwD3"
-                            class="primary-button" id="btn">Mathematics iv</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/folderview?id=1Q3pw3M_PgM3cw4J1LEkYGMq79lrUbIyf"
-                            class="primary-button" id="btn">UHV & PE</a>
-                    </div>
-                    <div class="About-card">
-
-                        <a href="https://drive.google.com/folderview?id=1Q3Ouof495LtHWFy6eWNLGzmuhtkqm3hf"
-                            class="primary-button" id="btn">Cyber Security</a>
-                    </div>
-
-                </div>
-                <div class="about " id="about"></div>
-                    <h1 class="service-heading" color="black">3rd year</h1>
-
-                    <div class="about-flex">
-                        <div class="About-card">
-                            <!-- <div class="icon">
-                <i class="fa-solid fa-code"></i>
-            </div>
-            <h2 class="name">Electrical</h2>-->
-                            <a href="https://drive.google.com/drive/folders/1whT8ikycNHYfvyCIRDhxo6vInkT40w7t"
-                                class="primary-button" id="btn">NTC PYQ</a>
+            <div class="papers-flex">
+                <div class="category-card">
+                    <div class="category-head">
+                        <div>
+                            <h3>1st Year</h3>
                         </div>
-
-                        <div class="About-card">
-
-                            <a href="https://drive.google.com/drive/folders/1JyZWE-DGau_ioZAt-fgjGfqSY8JQTJ8y"
-                                class="primary-button" id="btn">AI</a>
-                        </div>
-                        <div class="About-card">
-
-                            <a href="https://drive.google.com/drive/folders/1f6yflB4QmZeFbp38sZ73d1ziCY3Blvby"
-                                class="primary-button" id="btn">COI</a>
-                        </div>
-                        <div class="About-card">
-
-                            <a href="https://drive.google.com/drive/folders/18A33uKsuNYtTzCZGccvSS6OlOTrSBzcw"
-                                class="primary-button" id="btn">DAA</a>
-                        </div>
-                        <div class="About-card">
-
-                            <a href="https://drive.google.com/drive/folders/1V1r59GqmcVVmXZuqKQ0xcwRow8QVeHHn"
-                                class="primary-button" id="btn">DBMS</a>
-                        </div>
-                        <div class="About-card">
-
-                            <a href="https://drive.google.com/drive/folders/19D2paEna0dR_cIbG4vqo8CPFm6qCPW0z"
-                                class="primary-button" id="btn">OOSD WITH C++</a>
-                        </div>
-                        <div class="About-card">
-
-                            <a href="https://drive.google.com/drive/folders/1QNDbxhd1R597Y5pgdTDaTN0pakPNSZGh"
-                                class="primary-button" id="btn">Soft Computing</a>
-                        </div>
-                        <div class="About-card">
-
-                            <a href="https://drive.google.com/drive/folders/179CYOmp_YRyxbTqiYNrq3MyMuWy0pwh2"
-                                class="primary-button" id="btn">Web Technology</a>
-                        </div>
-
-
                     </div>
+                    <div class="topics">
+                        <!-- Topic: NTC PYQ -->
+                            <details class="topic" data-topic="NTC PYQ">
+                                <summary><span >NTC PYQ</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Chem,Electro,Mech,Math,Soft Papers -->
+                                <li class="note-item" data-title="Chem,Electro,Mech,Math,Soft Papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Chem,Electro,Mech,Math,Soft Papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1w5WHaNxf8_-PThepdZip9oQbJv3qIiwL/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1w5WHaNxf8_-PThepdZip9oQbJv3qIiwL/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                <!-- 1 sem sessional paper 24 -->
+                                <li class="note-item" data-title="1 sem sessional paper 24">
+                                    <span><i class="fa-regular fa-file-pdf"></i>1 Sem Sessional Paper 24</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1BRKZby0gqDYXwZl3dh1IxYzAe-BiDCN0/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1BRKZby0gqDYXwZl3dh1IxYzAe-BiDCN0/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Electrical -->
+                             <details class="topic" data-topic="Electrical">
+                                <summary><span >Electrical</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Electrical papers-->
+                                 <li class="note-item" data-title="Basic-Electrical-Engg-KEE101">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Electrical_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1caMn3EAQtjN1cr7ioEejUAnkm4KG4A4p/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1caMn3EAQtjN1cr7ioEejUAnkm4KG4A4p/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Physics -->
+                            <details class="topic" data-topic="Physics">
+                                <summary><span >Physics</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Physics papers -->
+                                <li class="note-item" data-title="Physics_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Physics_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1wlzY3N8z6XJXBlXbQSLFDeRRDS9F96jC/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1wlzY3N8z6XJXBlXbQSLFDeRRDS9F96jC/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Pps -->
+                            <details class="topic" data-topic="Pps">
+                                <summary><span >Pps</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Pps_papers -->
+                                <li class="note-item" data-title="Pps_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Pps_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1cwoNEHNwF6msknDOXJnYLPX96hA0yfVV/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1cwoNEHNwF6msknDOXJnYLPX96hA0yfVV/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Environment-->
+                            <details class="topic" data-topic="Environment">
+                                <summary><span >Environment</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Environment_papers -->
+                                <li class="note-item" data-title="Environment_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Environment_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1m5NfqWqbhGydVSszZmQGQutw_tXVYqLC/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1m5NfqWqbhGydVSszZmQGQutw_tXVYqLC/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Mathematics-II -->
+                            <details class="topic" data-topic="Mathematics-II">
+                                <summary><span >Mathematics-II</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- MathematicsII_papers -->
+                                <li class="note-item" data-title="MathematicsII_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>MathematicsII_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1kAmgh4RosBSawo-fvREnYcqpk89iB1iV/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1kAmgh4RosBSawo-fvREnYcqpk89iB1iV/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Electronics -->
+                            <details class="topic" data-topic="Electronics">
+                                <summary><span >Electronics</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Electronics_papers -->
+                                <li class="note-item" data-title="Electronics_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Electronics_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/13bkJEdC5CwTiqFEZLHz1KqFu3R8idv3e/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/13bkJEdC5CwTiqFEZLHz1KqFu3R8idv3e/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Chemistry -->
+                            <details class="topic" data-topic="Chemistry">
+                                <summary><span >Chemistry</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Chemistry_papers -->
+                                <li class="note-item" data-title="Chemistry_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Chemistry_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1amAcSv4sXgZ5VI6qi0d16ievRLM55Rc1/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1amAcSv4sXgZ5VI6qi0d16ievRLM55Rc1/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Mechanics -->
+                            <details class="topic" data-topic="Mechanics">
+                                <summary><span >Mechanics</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Mechanical_papers -->
+                                <li class="note-item" data-title="Mechanical_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Mechanical_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1ZF4DYeneS1t3LxQ6feBh2is1F1hZHwNe/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1ZF4DYeneS1t3LxQ6feBh2is1F1hZHwNe/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Soft Skill -->
+                            <details class="topic" data-topic="Soft Skill">
+                                <summary><span >Soft Skill</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- SoftSkill_papers -->
+                                <li class="note-item" data-title="SoftSkill_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>SoftSkill_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1hQTjV_BpFkrMve0TuNyrPgh_drzo07jU/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1hQTjV_BpFkrMve0TuNyrPgh_drzo07jU/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                    </div>
+                
+                </div>
 
+                <div class="category-card">
+                    <div class="category-head">
+                        <div>
+                            <h3>2nd Year</h3>
+                        </div>
+                    </div>
+                    <div class="topics">
+                         <!-- Topic: NTC PYQ -->
+                            <details class="topic" data-topic="NTC PYQ">
+                                <summary><span >NTC PYQ</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- 3-sem sessional pyq -->
+                                <li class="note-item" data-title="3-sem sessional pyq">
+                                    <span><i class="fa-regular fa-file-pdf"></i>3-sem sessional pyq</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1wxciTQrdpUQ2cjvkv68dnVZatREKFoN6/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1wxciTQrdpUQ2cjvkv68dnVZatREKFoN6/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                <!-- sem-4 sessional exam 23-24 -->
+                                <li class="note-item" data-title="sem-4 sessional exam 23-24">
+                                    <span><i class="fa-regular fa-file-pdf"></i>sem-4 sessional exam 23-24</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1G3IS-ZnXPjQW-0vfux6TvvsVQ0xdW_Uu/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1G3IS-ZnXPjQW-0vfux6TvvsVQ0xdW_Uu/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                <!-- cybersecurity 23-24 aktu sem4 -->
+                                <li class="note-item" data-title="cybersecurity 23-24 aktu sem4">
+                                    <span><i class="fa-regular fa-file-pdf"></i>cybersecurity 23-24 aktu sem4</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1GfgGwUG6gbZodB7bEzW4Q9kY9Zvb9aru/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1GfgGwUG6gbZodB7bEzW4Q9kY9Zvb9aru/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                <!-- Generated PDF from image files -->
+                                <li class="note-item" data-title="Generated PDF from image files">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Generated PDF from image files</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1GJZDjZh5EV68TR-9YiwYAqMmE8uTJiEZ/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1GJZDjZh5EV68TR-9YiwYAqMmE8uTJiEZ/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                <!-- oops with java 23-24 aktu sem4 pyq -->
+                                <li class="note-item" data-title="oops with java 23-24 aktu sem4 pyq">
+                                    <span><i class="fa-regular fa-file-pdf"></i>oops with java 23-24 aktu sem4 pyq</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1Gkf65L6AwyYSUjDNikz-qaBDVH16phsm/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1Gkf65L6AwyYSUjDNikz-qaBDVH16phsm/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                <!-- uhv 23-24 aktu sem4 pyq -->
+                                <li class="note-item" data-title="uhv 23-24 aktu sem4 pyq">
+                                    <span><i class="fa-regular fa-file-pdf"></i>uhv 23-24 aktu sem4 pyq</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1GswP270yevnUcLjeQSaJ2gtZzj8cxzna/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1GswP270yevnUcLjeQSaJ2gtZzj8cxzna/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: COA -->
+                            <details class="topic" data-topic="COA">
+                                <summary><span >COA</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- COA_papers -->
+                                <li class="note-item" data-title="COA_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>COA_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1qTLNyWXjHQRbQ9mRdxE90wKcbDuj9wP5/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1qTLNyWXjHQRbQ9mRdxE90wKcbDuj9wP5/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: DSA -->
+                            <details class="topic" data-topic="DSA">
+                                <summary><span >DSA</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/10VFvk7_9QabDx5cn2ZtbGMPoXtps1Jkc/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/10VFvk7_9QabDx5cn2ZtbGMPoXtps1Jkc/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Discrete Math -->
+                            <details class="topic" data-topic="Discrete Math">
+                                <summary><span >Discrete Math</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/10IkusBhWy_VU9FMgzdMZJGzQhNGahF6s/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/10IkusBhWy_VU9FMgzdMZJGzQhNGahF6s/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Python -->
+                            <details class="topic" data-topic="Python">
+                                <summary><span >Python</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- Python_papers -->
+                                <li class="note-item" data-title="Python_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>Python_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1g9v2uM_EG0WTJjxHIC1fqOtK6bYeBtKh/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1g9v2uM_EG0WTJjxHIC1fqOtK6bYeBtKh/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Tech. Comm. -->
+                            <details class="topic" data-topic="Tech. Comm.">
+                                <summary><span >Tech. Comm.</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/10IJXmgXS5nO1adH5MO7JD96PQ_EVr09g/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/10IJXmgXS5nO1adH5MO7JD96PQ_EVr09g/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: TAFL -->
+                            <details class="topic" data-topic="TAFL.">
+                                <summary><span >TAFL</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- TAFL_papers -->
+                                <li class="note-item" data-title="TAFL_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>TAFL_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1pNA-eFicBaKM5PROugZFBmRpncXAqQgW/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1pNA-eFicBaKM5PROugZFBmRpncXAqQgW/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Operating Sys. -->
+                            <details class="topic" data-topic="Operating Sys.">
+                                <summary><span >Operating Sys.</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- OperatingSys_papers -->
+                                <li class="note-item" data-title="OperatingSys_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>OperatingSys_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1-CttAKJefjd8zmT2O28rzE3Fh2W1gmKB/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1-CttAKJefjd8zmT2O28rzE3Fh2W1gmKB/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: JAVA -->
+                            <details class="topic" data-topic="JAVA">
+                                <summary><span >JAVA</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- JAVA_papers -->
+                                <li class="note-item" data-title="JAVA_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>JAVA_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1OHoThchVG7wYaLT6LP0swAvjI0HaU-ql/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1OHoThchVG7wYaLT6LP0swAvjI0HaU-ql/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Material Science -->
+                            <details class="topic" data-topic="Material Science">
+                                <summary><span >Material Science</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- MaterialScience_papers -->
+                                <li class="note-item" data-title="MaterialScience_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>MaterialScience_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1_xxQtsYjV8lChBTaTRiXd21ix9dvf5E7/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1_xxQtsYjV8lChBTaTRiXd21ix9dvf5E7/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Mathematics-IV -->
+                            <details class="topic" data-topic="Mathematics-IV">
+                                <summary><span >Mathematics-IV</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- MathematicsIV_papers -->
+                                <li class="note-item" data-title="MathematicsIV_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>MathematicsIV_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1HTfUp2GgQjKL5aGABz1UL3eaaA8OqGeM/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1HTfUp2GgQjKL5aGABz1UL3eaaA8OqGeM/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: UHV & PE -->
+                            <details class="topic" data-topic="UHV & PE">
+                                <summary><span >UHV & PE</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- UHV&PE_papers -->
+                                <li class="note-item" data-title="UHV&PE_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>UHV&PE_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1QWQ2OStnNJ7C8ejQXZWh4PmHLZa5PBNH/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1QWQ2OStnNJ7C8ejQXZWh4PmHLZa5PBNH/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                            <!-- Topic: Cyber Security -->
+                            <details class="topic" data-topic="Cyber Security">
+                                <summary><span >Cyber Security</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- CyberSecurity_papers -->
+                                <li class="note-item" data-title="CyberSecurity_papers">
+                                    <span><i class="fa-regular fa-file-pdf"></i>CyberSecurity_papers</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1L7qCv_dh3BeZERkZ-9Ij1P9uSQCWUzX4/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1L7qCv_dh3BeZERkZ-9Ij1P9uSQCWUzX4/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                    </div>
+                </div>
+                <!-- 3rd Year -->
+                     <div class="category-card">
+                        <div class="category-head">
+                            <div>
+                                <h3>
+                                    3rd Year
+                                </h3>
+                            </div>
+                        </div>
+                        <div class="topics">
+                                <!-- Topic: NTC PYQ -->
+                            <details class="topic" data-topic="NTC PYQ">
+                                <summary><span >NTC PYQ</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- v sem NTC PYQ 2024 -->
+                                <li class="note-item" data-title="v sem NTC PYQ 2024">
+                                    <span><i class="fa-regular fa-file-pdf"></i>v sem NTC PYQ 2024</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/17SZisyRcyGHKfHv9q5BudGUgdTww5ptv/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/17SZisyRcyGHKfHv9q5BudGUgdTww5ptv/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                <!-- sem 6 sessional pyq 24-25 -->
+                                <li class="note-item" data-title="sem 6 sessional pyq 24-25">
+                                    <span><i class="fa-regular fa-file-pdf"></i>sem 6 sessional pyq 24-25</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1GDggq37pyVPRynp-hc_S0BHRWPJ3n6GU/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1GDggq37pyVPRynp-hc_S0BHRWPJ3n6GU/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                                <!-- Topic: AI -->
+                            <details class="topic" data-topic="AI">
+                                <summary><span >AI</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1zjS8oR3voRLVkBNehnTxmZcZXVO90xCo/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1zjS8oR3voRLVkBNehnTxmZcZXVO90xCo/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                                <!-- Topic: COI -->
+                            <details class="topic" data-topic="COI">
+                                <summary><span >COI</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1znO4AWohLIVf6vmz6lyeiy2CveDnd-_Y/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1znO4AWohLIVf6vmz6lyeiy2CveDnd-_Y/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                                <!-- Topic: DAA -->
+                            <details class="topic" data-topic="DAA">
+                                <summary><span >DAA</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                 <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1zPBVdcOmtq9QNxpdD8VFMBU0rW9lZySq/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1zPBVdcOmtq9QNxpdD8VFMBU0rW9lZySq/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                                <!-- Topic: DBMS -->
+                            <details class="topic" data-topic="DBMS">
+                                <summary><span >DBMS</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                
+                                <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1zjoVCzPcJqxFI7Zrr4jbKlVcHnDE5s5i/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1zjoVCzPcJqxFI7Zrr4jbKlVcHnDE5s5i/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </li>
+                                </ul>
+                            </details>
+                                <!-- Topic: OOSD With C++ -->
+                            <details class="topic" data-topic="OOSD With C++">
+                                <summary><span >OOSD With C++</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1zixq8aCLm44xe3MMEZkCQdC936v0VIlj/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1zixq8aCLm44xe3MMEZkCQdC936v0VIlj/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                                <!-- Topic: Soft Computing -->
+                            <details class="topic" data-topic="Soft Computing">
+                                <summary><span >Soft Computing</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                                <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1zjZTg63yXF6JgDtSmsoQzF_LOfbfTNW9/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1zjZTg63yXF6JgDtSmsoQzF_LOfbfTNW9/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                                <!-- Topic: Web Technology -->
+                            <details class="topic" data-topic="Web Technology">
+                                <summary><span >Web Technology</span> <i class="fa-solid fa-chevron-down"></i></summary>
+                                <ul class="notes-list">
+                               <!-- coming soon -->
+                                <li class="note-item" data-title="coming soon">
+                                    <span><i class="fa-regular fa-file-pdf"></i>coming soon</span>
+                                    <div class="actions">
+                                    <button class="btn btn-sm btn-outline-primary preview-btn"
+                                            data-preview="https://drive.google.com/file/d/1zjZTg63yXF6JgDtSmsoQzF_LOfbfTNW9/view?usp=drive_link">
+                                        Preview
+                                    </button>
+                                    <a class="btn btn-sm btn-primary"
+                                        href="https://drive.google.com/file/d/1zjZTg63yXF6JgDtSmsoQzF_LOfbfTNW9/view?usp=drive_link"
+                                        target="_blank" rel="noopener">
+                                        Download
+                                    </a>
+                                    </div>
+                                </li>
+                                </ul>
+                            </details>
+                        </div>
+                     </div>
 
-
-
+            </div>
 
 
                     <div class="contribution">
@@ -322,12 +883,8 @@
                                 class="primary-button">Upload</a>
                         </div>
 
-
-
-
-
                     </div>
-               </div>
+                
             <div style="text-align: center;">
                 <h4 color="white">Total Visitors</h4>
                 <script type="text/javascript"></script>
@@ -500,12 +1057,62 @@
 
 
   <!-- Scroll features -->
-
-  <!-- Scroll features -->
   <script src="../js/scroll-indicator.js"></script>
     <!-- Floating Sidebar JavaScript -->
     <script src="../js/sidebar.js"></script>
+   
+
+<!-- PDF Modal -->
+<div id="pdfModal" class="pdf-modal">
+  <div class="pdf-modal-content">
+    <span class="pdf-modal-close">&times;</span>
+    <iframe id="pdfFrame" src="" width="100%" height="600px" frameborder="0"></iframe>
+  </div>
+</div>
+
+
+ <script>
+function makePreviewSrc(url) {
+  try {
+    const u = new URL(url, window.location.origin);
+    if (u.hostname.includes("drive.google.") && u.pathname.includes("/file/")) {
+      return url.replace(/\/view.*$/, "/preview");
+    }
+    if (u.searchParams.get("id")) {
+      const id = u.searchParams.get("id");
+      return `https://drive.google.com/file/d/${id}/preview`;
+    }
+  } catch (e) {}
+  return url;
+}
+
+const pdfFrame = document.getElementById("pdfFrame");
+const pdfModal = document.getElementById("pdfModal");
+const closeBtn = document.querySelector(".pdf-modal-close");
+
+document.querySelectorAll(".preview-btn").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    const src = btn.getAttribute("data-preview");
+    const finalSrc = makePreviewSrc(src);
+    pdfFrame.src = finalSrc;
+    pdfModal.style.display = "block";
+  });
+});
+
+closeBtn.addEventListener("click", () => {
+  pdfModal.style.display = "none";
+  pdfFrame.src = "";
+});
+
+window.addEventListener("click", (e) => {
+  if (e.target === pdfModal) {
+    pdfModal.style.display = "none";
+    pdfFrame.src = "";
+  }
+});
+</script>
+
+
 </body>
 
 </html>
-

--- a/pages/paper.html
+++ b/pages/paper.html
@@ -78,6 +78,10 @@
                 to
                 excel in your academic journey.</p>
 
+     <p class="text-muted">Choose a year -> open a subject -> preview or download PDFs</p>    
+   <div class="notes-search mx-auto">
+      <input id="notesSearch" type="text" class="form-control form-control-lg" placeholder="Search subjects or files (e.g., JAVA, Physics)" />
+    </div>
             <div class="papers-flex">
                 <div class="category-card">
                     <div class="category-head">
@@ -1111,6 +1115,25 @@ window.addEventListener("click", (e) => {
   }
 });
 </script>
+<script>
+  const searchInput = document.getElementById("notesSearch");
+  const topics = document.querySelectorAll(".topic"); // all <details> blocks
+
+  searchInput.addEventListener("keyup", function () {
+    const query = searchInput.value.toLowerCase().trim();
+
+    topics.forEach(topic => {
+      const subjectName = topic.querySelector("summary span").textContent.toLowerCase();
+
+      if (subjectName.includes(query)) {
+        topic.style.display = "block";  // show subject
+      } else {
+        topic.style.display = "none";   // hide subject
+      }
+    });
+  });
+</script>
+
 
 
 </body>


### PR DESCRIPTION
## 🔖 PR Title:
Redesign Papers Page Layout to Match Notes Page
---

## 📄 Description:
The Papers page (paper.html) had a layout inconsistent with the Notes page (tech.html). The Notes page uses collapsible semester sections under each branch (CSE, ECE, ECM), providing a cleaner navigation experience.

This PR redesigns the Papers page to follow a similar, user-friendly structure:
-Redesign Papers page to mirror the Notes page layout.
-Organize exam papers year-wise (1st Year, 2nd Year, etc.).
-Display columns of subject names under each year instead of collapsible branch/semester lists.
-Maintain consistent styling with Notes page (rounded cards, dropdowns, uniform spacing

-  Enhancement 🔧
- UI/UX Update 🎨

---

## 🧑‍💻 What changes were made?
- Redesigned paper.html to have a consistent layout with tech.html.
- Updated CSS for cards, spacing, and dropdowns to match Notes page styling.
- Added year-wise organization of exam papers with columns of subjects.

---

## 💡 Tech Stack Used:
- HTML / CSS / JavaScript

---

## List of File Changed :
- paper.html
- paper.css

# no. of file changed :
2


## 🔗 Issue Reference:
<!-- Mention the issue number this PR fixes -->
Closes #413

---

## 🧩 Contribution Type:
- Frontend 🎯
- UI/UX 🎨
- Optimization ♻️

## 🖼️ Screenshot or Screen Recording (max 15 seconds)
Before:
<img width="2880" height="1722" alt="Screenshot (608)" src="https://github.com/user-attachments/assets/2aec3909-9279-44b4-b8ba-30b4c5f9e1ed" />

After:
<img width="2880" height="1731" alt="Screenshot (609)" src="https://github.com/user-attachments/assets/ef02520b-adf2-4fc0-9312-7c965f1d4c48" />

