### PR TITLE
🐛 [Fix] Improve text visibility in dark mode for resourses page

### DIFF
--- a/index.css
+++ b/index.css
@@ -46,7 +46,6 @@
 
 
 
-
 .main:not(.dark-mode){
   
     margin-top: 60px; /* Updated to match navbar height */
@@ -1923,7 +1922,29 @@ body.dark-mode #cgpa-result {
   border-radius: 10px;
   box-shadow: 0 2px 8px #85611333;
 }
+ 
+body.dark-mode .note-info span,
+body.dark-mode .category-card,
+body.dark-mode .form-control,
+body.dark-mode .topic summary span {
+  color: black !important;
+}
 
+body.dark-mode .text-muted{
+  color:white !important;
+}
+
+body.dark-mode #notesSearch {
+  color: white !important;            /* typed text */
+  background-color: #222 !important;  /* dark background */
+  border: 1px solid #555 !important;  /* subtle border */
+}
+
+/* Placeholder text color */
+body.dark-mode #notesSearch::placeholder {
+  color: white !important;
+  opacity: 0.7;
+}
 
 .result-box {
     background-color: #f8f9fa;

--- a/pages/subject.html
+++ b/pages/subject.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="../css/scroll-indicator.css" />
     <!-- Floating Sidebar CSS -->
     <link rel="stylesheet" href="../css/floating-sidebar.css">
+   
 </head>
 
 <body id="onload">


### PR DESCRIPTION
PR Title:
Fixed text and placeholder visibility for Notes Search input in dark mode

Description:
This PR fixes the issue where the search input text and placeholder were not clearly visible in dark mode. Added proper CSS overrides to ensure readability with white text on a dark background.
[x] Bug Fix 

What changes were made?
Added custom CSS for #notesSearch input in dark mode
Ensured typed text is white for better readability
Ensured placeholder text is white with reduced opacity
Set background color to dark gray and border to subtle gray in dark mode

Screenshot:
<img width="1894" height="906" alt="Screenshot 2025-09-21 223819" src="https://github.com/user-attachments/assets/ae95eac4-0f45-4ef4-a678-2d2a9a760ff2" />
<img width="1893" height="904" alt="Screenshot 2025-09-21 223836" src="https://github.com/user-attachments/assets/068aaee1-e82f-4852-9f9a-12ff1a2b209c" />
<img width="1889" height="911" alt="Screenshot 2025-09-21 223902" src="https://github.com/user-attachments/assets/26fa6794-b55c-4f3e-99cc-c2c5223f49ed" />


💡 Tech Stack Used:
HTML
CSS
Bootstrap

List of File Changed :
index.css
no. of file changed : 1

Issue Reference:
Closes #448

Contribution Type:
[x] UI/UX 
[x] Bug Fix